### PR TITLE
Update Starfield-DDS-Exporter.py

### DIFF
--- a/Starfield-DDS-Exporter.py
+++ b/Starfield-DDS-Exporter.py
@@ -2,8 +2,8 @@ __author__ = "Emil Eldstål"
 __copyright__ = "Copyright 2023, Emil Eldstål"
 __version__ = "0.1.1"
 
-from PySide2 import QtWidgets
-from PySide2.QtCore import Qt
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
 
 import substance_painter.ui
 import substance_painter.event


### PR DESCRIPTION
Substance now uses PySide6 instead of 2 in newer versions so this plugin is broken without this change.